### PR TITLE
Bug fix: update run-job.sh to take jobs/some_job.py as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ With `batect`, the only dependencies that need to be installed are Docker and Ja
 scripts/go.sh
 
 # For windows/linux users:
-# TODO: create go script to ensure docker and java >=8 is installed
+# Please ensure Docker and java >=8 is installed 
+# TODO: add link for installing java on windows/linux
 ```
 
 ## Run tests

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A single `*.csv` file containing data similar to:
 #### Run the job
 
 ```bash
-./batect run-job
+JOB=jobs/word_count.py ./batect run-job 
 ```
 
 ### Citibike
@@ -104,7 +104,7 @@ Historical bike ride `*.csv` file:
 ##### Run the job
 
 ```bash
-./batect run-job
+JOB=jobs/citibike_ingest.py ./batect run-job
 ```
 
 #### Distance calculation
@@ -133,5 +133,5 @@ Historical bike ride `*.parquet` files
 ##### Run the job
 
 ```bash
-./batect run-job
+JOB=jobs/citibike_distance_calculation.py ./batect run-job
 ```

--- a/batect.yml
+++ b/batect.yml
@@ -37,3 +37,5 @@ tasks:
     run:
       container: pyspark
       entrypoint: scripts/run-job.sh
+      environment:
+        JOB: $JOB

--- a/scripts/run-job.sh
+++ b/scripts/run-job.sh
@@ -7,9 +7,11 @@ poetry build
 INPUT_FILE_PATH="./resources/citibike/citibike.csv"
 OUTPUT_PATH="./output"
 
+rm -rf $OUTPUT_PATH
+
 poetry run spark-submit \
     --master local \
     --py-files dist/data_transformations-*.whl \
-    jobs/word_count.py \
+    $JOB \
     $INPUT_FILE_PATH \
     $OUTPUT_PATH


### PR DESCRIPTION
Changes:
- Bug fix: update run-job.sh to take `jobs/some_job.py` as argument
- Add TODO for installing java

Heya @svishal9 , for the [setup](https://github.com/svishal9/dataengineer-transformations-python/commit/5b7d0a77e908f02466276613cf85881d2d9cc20f), could you add a link for manually installing java >=8? Ideally it should be done in a `go` script, but I'm not sure if it's possible to assume what shell and OS package manager people are using on Windows - so I think a link/command installing in manually should suffice.